### PR TITLE
Adding service version logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,9 @@ addEventListener("fetch", (event) => event.respondWith(handleRequest(event)));
 
 // Validates all requests against an OpenAPI definition.
 async function handleRequest(event) {
+  // Log service version
+  console.log("FASTLY_SERVICE_VERSION:", fastly.env.get('FASTLY_SERVICE_VERSION' || ''));
+  
   // Initialize an OpenAPI validator using the OpenAPI definition.
   // https://github.com/anttiviljami/openapi-backend/blob/master/DOCS.md#new-openapivalidatoropts
   const openAPIValidator = new OpenAPIValidator({


### PR DESCRIPTION
Part of the quest to add version logging to every starter kit. Prints the service version to the console after running `fastly log-tail`. ([JIRA ticket](https://fastly.atlassian.net/browse/DEVLIB-856?atlOrigin=eyJpIjoiOWMyM2JjMDU1YjRjNGM1YTg5NjQzMzdhYzM1NTEyYjkiLCJwIjoiaiJ9))