### PR TITLE
Use @fastly/cli in the starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,27 @@ This starter kit makes it possible to define custom request handling logic at th
 
 ✅ Improved API security
 
-## Usage
+## Running the application
+
+To create an application using this starter kit, create a new directory for your application and switch to it, and then type the following command:
+
+```shell
+npm create @fastly/compute@latest -- --language=javascript --starter-kit=openapi-validation
+```
 
 Replace the contents of `src/definition.json` with your own OpenAPI 3.x definition, and change any references to `httpbin.org` to your origin in `fastly.toml` – by replacing the `url` in `local_server.backends.origin`, and the `address` (hostname) in `setup.backends.origin`.
 
-Then run `fastly compute serve` to try out this Compute app on your local machine, or `fastly compute publish` to publish a new Compute service.
+To build and run your new application in the local development environment, type the following command:
+
+```shell
+npm run start
+```
+
+To build and deploy your application to your Fastly account, type the following command. The first time you deploy the application, you will be prompted to create a new service in your account.
+
+```shell
+npm run deploy
+```
 
 ### Request handling
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -9,6 +9,7 @@ name = "OpenAPI Validation (JS)"
 
 [scripts]
   build = "npm run build"
+  post_init = "npm install"
 
 [local_server]
   [local_server.backends]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "node": "^18"
   },
   "devDependencies": {
+    "@fastly/cli": "^10.14.0",
     "buffer": "^6.0.3",
     "core-js": "^3.33.1",
     "g": "^2.0.1",
@@ -20,6 +21,7 @@
   "scripts": {
     "prebuild": "webpack",
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
+    "start": "fastly compute serve",
     "deploy": "fastly compute publish"
   }
 }


### PR DESCRIPTION
This PR makes changes:

* Changes to **package.json** to enable usage without a global installation of the Fastly CLI:
   * Adds `@fastly/cli` to `devDependencies` so that it's available when using the starter kit, as a tool used to build and run or publish the application.
   * Makes sure that `scripts` contains `start` and `deploy` scripts as applicable.

* Adds instructions to the README describing how to initialize an application using the starter kit, as well as how to run it locally or publish it to a Fastly service, as applicable.

* Adds `post_init` script to run `npm install` if it was not present.