### PR TITLE
Consistent package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20.11'
       - name: Setup Fastly CLI
         uses: fastly/compute-actions/setup@v5
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
-  "engines": {
-    "node": "^18"
+  "type": "commonjs",
+  "private": true,
+  "dependencies": {
+    "@fastly/js-compute": "^3.33.2"
   },
   "devDependencies": {
-    "@fastly/cli": "^10.14.0",
+    "@fastly/cli": "^11.0.0",
     "buffer": "^6.0.3",
     "core-js": "^3.33.1",
     "g": "^2.0.1",
@@ -12,11 +14,8 @@
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "stream-http": "^3.2.0",
-    "webpack": "^5.89.0",
+    "webpack": "^5.98.0",
     "webpack-cli": "^5.1.4"
-  },
-  "dependencies": {
-    "@fastly/js-compute": "^3.0.0"
   },
   "scripts": {
     "prebuild": "webpack",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "type": "commonjs",
+  "type": "module",
   "private": true,
   "dependencies": {
     "@fastly/js-compute": "^3.33.2"
@@ -22,5 +22,8 @@
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
     "start": "fastly compute serve",
     "deploy": "fastly compute publish"
+  },
+  "engines": {
+    "node": ">= 20.11"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,10 @@
-const path = require("path");
-const webpack = require("webpack");
+import { createRequire } from "module";
+import path from "path";
+import webpack from "webpack";
 
-module.exports = {
+const require = createRequire(import.meta.url);
+
+export default {
   entry: "./src/index.js",
   optimization: {
     minimize: true,
@@ -9,7 +12,7 @@ module.exports = {
   target: "webworker",
   output: {
     filename: "index.js",
-    path: path.resolve(__dirname, "bin"),
+    path: path.resolve(import.meta.dirname, "bin"),
     libraryTarget: "this",
   },
   module: {


### PR DESCRIPTION
This PR makes package.json consistent across the various JavaScript (TypeScript) starter kits.

1. As this is a template, removes fields that we would not want downstream projects to inherit if they were set:
   * package name, author, bugs, homepage, repository, license, version

2. As the package created from the template is an application:
   * sets private: true
   * removes main if it was set

3. Removes any engine requirement, as it is unneeded (and has been removed from js-compute since 3.14.0 as well).

4. Updates @fastly/cli to version ^11.0.0 (latest major release) and @fastly/js-compute to ^3.33.2 (includes latest crash fix)
   * if package depends on webpack, updates it to ^5.98.0, which includes a security fix

5. Places `dependencies`, `devDependencies`, `scripts` consistently in this order.
